### PR TITLE
feat: execute workflow Implementation

### DIFF
--- a/plugins/orchestrator-backend/src/service/handlers.ts
+++ b/plugins/orchestrator-backend/src/service/handlers.ts
@@ -1,6 +1,8 @@
 import moment from 'moment';
 
 import {
+  ExecuteWorkflowRequestDTO,
+  ExecuteWorkflowResponseDTO,
   getWorkflowCategoryDTO,
   ProcessInstance,
   ProcessInstanceDTO,
@@ -11,6 +13,7 @@ import {
   WorkflowCategoryDTO,
   WorkflowDefinition,
   WorkflowDTO,
+  WorkflowExecutionResponse,
   WorkflowInfo,
   WorkflowItem,
   WorkflowListResult,
@@ -57,6 +60,67 @@ export async function getWorkflowOverviewV2(
     },
   };
   return result;
+}
+
+export async function executeWorkflowByIdV1(
+  dataIndexService: DataIndexService,
+  sonataFlowService: SonataFlowService,
+  reqBody,
+  workflowId: string,
+): Promise<WorkflowExecutionResponse> {
+  const definition = await dataIndexService.getWorkflowDefinition(workflowId);
+  const serviceUrl = definition.serviceUrl;
+  if (!serviceUrl) {
+    throw new Error(`ServiceURL is not defined for workflow ${workflowId}`);
+  }
+  const executionResponse = await sonataFlowService.executeWorkflow({
+    workflowId,
+    inputData: reqBody.inputData,
+    endpoint: serviceUrl,
+  });
+
+  if (!executionResponse) {
+    throw new Error(`Couldn't execute workflow ${workflowId}`);
+  }
+  return executionResponse;
+}
+
+export async function executeWorkflowByIdV2(
+  dataIndexService: DataIndexService,
+  sonataFlowService: SonataFlowService,
+  executeWorkflowRequestDTO: ExecuteWorkflowRequestDTO,
+  workflowId: string,
+): Promise<ExecuteWorkflowResponseDTO> {
+  if (!dataIndexService) {
+    throw new Error(
+      `No data index service provided for executing workflow with id ${workflowId}`,
+    );
+  }
+
+  if (!sonataFlowService) {
+    throw new Error(
+      `No sonata flow service provided for executing workflow with id ${workflowId}`,
+    );
+  }
+
+  if (Object.keys(executeWorkflowRequestDTO?.inputData).length === 0) {
+    throw new Error(
+      `ExecuteWorkflowRequestDTO.inputData is required for executing workflow with id ${workflowId}`,
+    );
+  }
+
+  const executeWorkflowResponse = await executeWorkflowByIdV1(
+    dataIndexService,
+    sonataFlowService,
+    executeWorkflowRequestDTO,
+    workflowId,
+  );
+
+  if (!executeWorkflowResponse) {
+    throw new Error('Error executing workflow with id ${workflowId}');
+  }
+
+  return mapToExecuteWorkflowResponseDTO(workflowId, executeWorkflowResponse);
 }
 
 export async function getWorkflowOverviewByIdV1(
@@ -310,4 +374,19 @@ function getProcessInstancesDTOFromString(
       // TODO: What is the default value?
       return ProcessInstanceStatusDTO.SUSPENDED;
   }
+}
+
+function mapToExecuteWorkflowResponseDTO(
+  workflowId: string,
+  workflowExecutionResponse: WorkflowExecutionResponse,
+): ExecuteWorkflowResponseDTO {
+  if (!workflowExecutionResponse || !workflowExecutionResponse?.id) {
+    throw new Error(
+      `Error while mapping ExecuteWorkflowResponse to ExecuteWorkflowResponseDTO for workflow with id ${workflowId}`,
+    );
+  }
+
+  return {
+    id: workflowExecutionResponse.id,
+  };
 }

--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -29,6 +29,8 @@ import { CloudEventService } from './CloudEventService';
 import { DataIndexService } from './DataIndexService';
 import { DataInputSchemaService } from './DataInputSchemaService';
 import {
+  executeWorkflowByIdV1,
+  executeWorkflowByIdV2,
   getInstancesByIdV1,
   getInstancesByIdV2,
   getInstancesV1,
@@ -275,24 +277,36 @@ function setupInternalRoutes(
       params: { workflowId },
     } = req;
 
-    const definition = await dataIndexService.getWorkflowDefinition(workflowId);
-    const serviceUrl = definition.serviceUrl;
-    if (!serviceUrl) {
-      throw new Error(`ServiceURL is not defined for workflow ${workflowId}`);
-    }
-    const executionResponse = await sonataFlowService.executeWorkflow({
+    await executeWorkflowByIdV1(
+      dataIndexService,
+      sonataFlowService,
+      req.body,
       workflowId,
-      inputData: req.body,
-      endpoint: serviceUrl,
-    });
-
-    if (!executionResponse) {
-      res.status(500).send(`Couldn't execute workflow ${workflowId}`);
-      return;
-    }
-
-    res.status(200).json(executionResponse);
+    )
+      .then((result: any) => res.status(200).json(result))
+      .catch((error: { message: any }) => {
+        res.status(500).send(error.message || 'Internal Server Error');
+      });
   });
+
+  // v2
+  api.register(
+    'executeWorkflow',
+    async (c, req: express.Request, res: express.Response, next) => {
+      const workflowId = c.request.params.workflowId as string;
+      const executeWorkflowRequestDTO = req.body;
+      await executeWorkflowByIdV2(
+        dataIndexService,
+        sonataFlowService,
+        executeWorkflowRequestDTO,
+        workflowId,
+      )
+        .then(result => res.status(200).json(result))
+        .catch((error: { message }) => {
+          res.status(500).send(error.message || 'Internal Server Error');
+        });
+    },
+  );
 
   router.get('/workflows/:workflowId/overview', async (req, res) => {
     const {

--- a/plugins/orchestrator-common/api/models/schema.d.ts
+++ b/plugins/orchestrator-common/api/models/schema.d.ts
@@ -246,7 +246,7 @@ export interface components {
                 [key: string]: string | undefined;
             };
         };
-        ExecuteWorkflowResponse: {
+        ExecuteWorkflowResponseDTO: {
             id?: string;
         };
         NodeInstanceDTO: {
@@ -597,7 +597,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ExecuteWorkflowResponse"];
+                    "application/json": components["schemas"]["ExecuteWorkflowResponseDTO"];
                 };
             };
             /** @description Internal Server Error */

--- a/plugins/orchestrator-common/api/openapi.yaml
+++ b/plugins/orchestrator-common/api/openapi.yaml
@@ -295,7 +295,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExecuteWorkflowResponse'
+                $ref: '#/components/schemas/ExecuteWorkflowResponseDTO'
         '500':
           description: Internal Server Error
           content:
@@ -544,7 +544,7 @@ components:
             type: string
       required:
         - inputData
-    ExecuteWorkflowResponse:
+    ExecuteWorkflowResponseDTO:
       type: object
       properties:
         id:

--- a/plugins/orchestrator-common/src/openapi_types.ts
+++ b/plugins/orchestrator-common/src/openapi_types.ts
@@ -8,8 +8,10 @@ export type WorkflowListResultDTO =
   components['schemas']['WorkflowListResultDTO'];
 export type ProcessInstanceDTO = components['schemas']['ProcessInstanceDTO'];
 export type ProcessInstancesDTO = components['schemas']['ProcessInstancesDTO'];
-export type WorkflowRunStatusDTO =
-  components['schemas']['WorkflowRunStatusDTO'];
+export type ExecuteWorkflowRequestDTO =
+  components['schemas']['ExecuteWorkflowRequestDTO'];
+export type ExecuteWorkflowResponseDTO =
+  components['schemas']['ExecuteWorkflowResponseDTO'];
 
 // FIX ME
 export enum ProcessInstanceStatusDTO {


### PR DESCRIPTION
Hi Gloria,
This is initial implementation of execute workflow as per OpenAPI specs. Please advise or approve.

Thanks,
Kamlesh.

**Example successful run - V1**

```
curl --location 'localhost:7007/api/orchestrator/workflows/yamlgreet/execute' \
--header 'Content-Type: application/json' \
--data '{
  "inputData": {
      "name": "My custom name",
      "customMessage" : "My customMessage"
    }
}'
```
<img width="983" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/78913e20-1754-4bfb-8216-1fdacf4974a3">

**Example successful run - V2**
```
curl --location 'localhost:7007/api/orchestrator/v2/workflows/yamlgreet/execute' \
--header 'Content-Type: application/json' \
--data '{
  "inputData": {
      "name": "My custom name",
      "customMessage" : "My customMessage"
    }
}'
```
<img width="968" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/33d50833-bb15-4c18-8d37-c129ad42f305">
