### PR TITLE
fix: sonarlint issue - executeWorkflowById (V2)

### DIFF
--- a/plugins/orchestrator-backend/src/service/handlers.ts
+++ b/plugins/orchestrator-backend/src/service/handlers.ts
@@ -398,7 +398,7 @@ function mapToExecuteWorkflowResponseDTO(
   workflowId: string,
   workflowExecutionResponse: WorkflowExecutionResponse,
 ): ExecuteWorkflowResponseDTO {
-  if (!workflowExecutionResponse || !workflowExecutionResponse?.id) {
+  if (!workflowExecutionResponse?.id) {
     throw new Error(
       `Error while mapping ExecuteWorkflowResponse to ExecuteWorkflowResponseDTO for workflow with id ${workflowId}`,
     );


### PR DESCRIPTION
Hi Gloria,
Please find the executeWorkflowById (V2)'s fix for Sonarlint warning. Please advise of changes that may be needed or approve.

Thanks,
Kamlesh.

**curl**
curl --location 'localhost:7007/api/orchestrator/workflows/hello_world/execute' \
--header 'Content-Type: application/json' \
--data '{
  "inputData": {
      "name": "My custom name",
      "customMessage" : "My customMessage"
    }
}'

**v1**
<img width="984" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/5a98437c-b8c3-4110-ad38-f53d89f560a6">

**v2**
<img width="972" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/c6d58580-047b-4b72-ad15-523bb891e4f9">

**Local build**
<img width="732" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/926d6b9a-ea53-468e-9d6e-ea21d1769ab4">

**Local test**
<img width="642" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/5091d60f-85ce-4939-8a00-bb717a810caf">

**Local tsc**
<img width="859" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/0d6836ee-fca3-4e1c-b7d7-4b1eb83e8d36">

**Local prettier**
<img width="356" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/041fd2b1-e3f5-4a33-ae03-9d4095aa17c4">

 