### PR TITLE
feat: implement getWorkflowResultsByInstanceId (V2)

### DIFF
--- a/plugins/orchestrator-backend/src/service/handlers.ts
+++ b/plugins/orchestrator-backend/src/service/handlers.ts
@@ -398,7 +398,7 @@ function mapToExecuteWorkflowResponseDTO(
   workflowId: string,
   workflowExecutionResponse: WorkflowExecutionResponse,
 ): ExecuteWorkflowResponseDTO {
-  if (!workflowExecutionResponse || !workflowExecutionResponse?.id) {
+  if (!workflowExecutionResponse?.id) {
     throw new Error(
       `Error while mapping ExecuteWorkflowResponse to ExecuteWorkflowResponseDTO for workflow with id ${workflowId}`,
     );

--- a/plugins/orchestrator-backend/src/service/handlers.ts
+++ b/plugins/orchestrator-backend/src/service/handlers.ts
@@ -100,12 +100,6 @@ export async function getWorkflowResultsByInstanceIdV2(
 
   const instanceResult = await getInstancesByIdV1(dataIndexService, instanceId);
 
-  if (instanceResult?.category !== WorkflowCategory.ASSESSMENT) {
-    throw new Error(
-      `Error: the workflow instance with instance id ${instanceId} is not of assessment type`,
-    );
-  }
-
   if (!instanceResult?.variables) {
     throw new Error(
       'Error getting workflow instance results with id ' + instanceId,

--- a/plugins/orchestrator-backend/src/service/router.ts
+++ b/plugins/orchestrator-backend/src/service/router.ts
@@ -33,6 +33,7 @@ import {
   getWorkflowOverviewById,
   getWorkflowOverviewV1,
   getWorkflowOverviewV2,
+  getWorkflowResultsByInstanceIdV2,
   getWorkflowSpecsV2,
   getWorkflowStatuses,
   getWorkflowsV1,
@@ -262,6 +263,23 @@ function setupInternalRoutes(
 
     res.status(200).json(result.data);
   });
+
+  // v2
+  api.register(
+    'getAssessmentResults',
+    async (c, _req: express.Request, res: express.Response) => {
+      const instanceId = c.request.params.instanceId as string;
+
+      await getWorkflowResultsByInstanceIdV2(
+        services.dataIndexService,
+        instanceId,
+      )
+        .then(result => res.status(200).json(result))
+        .catch((error: { message: string }) => {
+          res.status(500).send(error.message || 'Internal Server Error');
+        });
+    },
+  );
 
   router.post('/workflows/:workflowId/execute', async (req, res) => {
     const {

--- a/plugins/orchestrator-common/src/openapi/types.ts
+++ b/plugins/orchestrator-common/src/openapi/types.ts
@@ -18,8 +18,9 @@ export type ExecuteWorkflowResponseDTO =
   components['schemas']['ExecuteWorkflowResponseDTO'];
 export type WorkflowSuggestionDTO =
   components['schemas']['WorkflowSuggestionDTO'];
+export type WorkflowDataDTO = components['schemas']['WorkflowDataDTO'];
 
-  // Generate ts enum instead of strings union
+// Generate ts enum instead of strings union
 // https://issues.redhat.com/browse/FLPATH-947
 export enum WorkflowCategoryDTO {
   // Assessment Workflow


### PR DESCRIPTION
Hi Gloria,
Please find the implementation of getWorkflowResultsByInstanceId (V2). Let me know what do you think?

Thanks,
Kamlesh.

**curl**
curl --location 'localhost:7007/api/orchestrator/v2/workflows/instances/<Your Workflow Instance Id>/result' \
--data ''

**Result - Assessment Workflow**
<img width="1022" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/49a39124-5aa1-4cab-a006-7310d9592ed9">

**Result - Non-assessment(e.g. Infrastructure) Workflow**
<img width="1024" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/245af505-b297-4721-8c21-7c9cfe32c385">

**Local Build - Feb 7th 10:15am**
<img width="747" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/f0e4c48b-b05c-484f-a53f-fb232c346937">

**Local Test - Feb 7th 10:15am**
<img width="1028" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/112d12e7-6225-42c2-993b-01ab98b72118">

**Local TSC - Feb 7th 10:15am**
<img width="817" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/998fa8d7-778d-43cc-ad04-68edf67badc3">

**Local Prettier - Feb 7th 10:15am**
<img width="352" alt="image" src="https://github.com/gciavarrini/backstage-plugins/assets/87712456/8f5dfeb1-aecb-4b17-b5eb-8f7e7d6f99c0">
